### PR TITLE
Fix brightness keys on mac

### DIFF
--- a/config/slicemk_ergodox.keymap
+++ b/config/slicemk_ergodox.keymap
@@ -23,7 +23,7 @@
 			bindings = <
 				&bootloader
 				&trans   &kp F1       &kp F2       &kp F3     &kp F4 &kp F5       &trans       &to 0                &kp F6               &kp F7   &kp F8  &kp F9               &kp F10              &trans
-				&kp CAPS &trans       &trans       &trans     &trans &trans       &trans       &trans               &kp F11              &kp F12  &kp F13 &kp C_BRIGHTNESS_DEC &kp C_BRIGHTNESS_INC &trans
+				&kp CAPS &trans       &trans       &trans     &trans &trans       &trans       &trans               &kp F11              &kp F12  &kp F13 &kp F14              &kp F15              &trans
 				&trans   &kp C_VOL_DN &kp C_VOL_UP &kp C_MUTE &trans &trans                                         &kp LEFT             &kp DOWN &kp UP  &kp RIGHT            &trans               &trans
 				&trans   &kp C_PREV   &kp C_NEXT   &kp C_PP   &trans &trans       &none        &none                &trans               &trans   &trans  &trans               &trans               &trans
 				&trans   &trans       &trans       &trans     &trans                                                                     &trans   &trans  &trans               &trans               &none


### PR DESCRIPTION
Use F14 and F15 to control brightness, because `C_BRIGHTNESS_DEC` and `C_BRIGHTNESS_INC` do not work on mac


Related to zmkfirmware/zmk#1045

----

> Default keyboard shortcut settings for controlling display brightness on macos ventura:
> <img width="827" alt="mac os keyboard settings - display shortcuts" src="https://user-images.githubusercontent.com/515861/200004325-30f24b60-e7b1-4e56-8bf0-d014c8eb0db0.png">
